### PR TITLE
Fix an issue that prevents ftplugin from working

### DIFF
--- a/ftplugin/mustache.vim
+++ b/ftplugin/mustache.vim
@@ -1,7 +1,7 @@
-if exists('g:loaded_mustache_handlebars') && g:loaded_mustache_handlebars
+if exists('b:loaded_mustache_handlebars')
   finish
 endif
-let g:loaded_mustache_handlebars = 1
+let b:loaded_mustache_handlebars = 1
 
 let s:cpo_save = &cpo
 set cpo&vim


### PR DESCRIPTION
ftplugin was working only for the first loaded mustache file. This was
happening because a global variable was used to check for ftplugin
re-execution. The issue was solved by using a buffer variable instead of
the global one.